### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test-install:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ultralytics/mobileclip/security/code-scanning/1](https://github.com/ultralytics/mobileclip/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/ci.yml` at the workflow root (right after `on:` block and before `jobs:`), with `contents: read`. This applies least privilege to all jobs unless overridden and preserves current functionality, since checkout/read operations continue to work.

Single best fix for the shown file:
- Edit `.github/workflows/ci.yml`
- Insert:
  - `permissions:`
  - `  contents: read`
- Place it between the trigger section and `jobs:` so it is clear and applies globally.

No imports, methods, or extra definitions are needed (YAML workflow config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔒 This PR tightens GitHub Actions security by explicitly giving the CI workflow read-only access to repository contents.

### 📊 Key Changes
- Added a top-level `permissions` block to `.github/workflows/ci.yml`
- Set `contents: read` for the CI workflow
- No changes to tests, build steps, or application code

### 🎯 Purpose & Impact
- Improves security by following GitHub Actions best practices and limiting workflow permissions to only what is needed 🛡️
- Reduces the risk of accidental or unnecessary write access during CI runs
- Helps make the repository’s automation more compliant with least-privilege standards
- Has minimal user-facing impact, since it should not change normal testing behavior or results ✅