### PR TITLE
Document upstream MobileCLIP2 resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This repository is an Ultralytics fork of Apple's official [MobileCLIP: Fast Ima
 
 ## 📰 What's New
 
+- **2026/04/15:** Apple's upstream repository added MobileCLIP-S3/S4 resources and previously released MobileCLIP2. This fork intentionally keeps the local Python package focused on the MobileCLIP API used by Ultralytics; see the [Apple ML-MobileCLIP repository](https://github.com/apple/ml-mobileclip) for upstream-only MobileCLIP2 assets, training updates, and result artifacts.
 - **2024/11/22:** iOS app released for real-time zero-shot image classification with MobileCLIP. Explore the [iOS app](./ios_app/).
 - **2024/06/13:** Training scripts for [OpenCLIP](https://github.com/mlfoundations/open_clip/tree/main/src/open_clip) on DataCompDR datasets are now available. See [training/](./training/).
 - **2024/06/13:** MobileCLIP models and DataCompDR datasets are hosted on Hugging Face in the [MobileCLIP/DataCompDR Collection](https://huggingface.co/collections/apple/mobileclip-models-datacompdr-data).
@@ -108,6 +109,8 @@ Available variants on OpenCLIP:
 - MobileCLIP-S2 (`datacompdr`)
 - MobileCLIP-B (`datacompdr`)
 - MobileCLIP-B (`datacompdr_lt`)
+
+For MobileCLIP2 and MobileCLIP-S3/S4 OpenCLIP resources, use the upstream [Apple ML-MobileCLIP](https://github.com/apple/ml-mobileclip) release directly. Those files are not vendored here so this fork remains a small, `pyproject.toml`-based package compatible with Ultralytics installs.
 
 ## 📊 Evaluation
 


### PR DESCRIPTION
## Summary
- document that Apple's upstream ML-MobileCLIP now has MobileCLIP2 and MobileCLIP-S3/S4 resources
- link users to the parent repository for upstream-only assets, training updates, and result artifacts
- keep this fork scoped as a small `pyproject.toml` package that preserves the MobileCLIP API used by Ultralytics

## Scope
- README-only change
- no vendored images or binary assets
- no upstream `setup.py` or `requirements.txt`
- no MobileCLIP2 code, training scripts, result artifacts, or license files added
- no changes to `LICENSE`, `pyproject.toml`, or the `mobileclip` package runtime API

## Compatibility
- verified `../ultralytics` uses `mobileclip.create_model_and_transforms(...)` and `mobileclip.get_tokenizer(...)`
- installed this branch and `../ultralytics` together in an isolated Python 3.11 `uv` environment
- verified the exact `ultralytics.nn.text_model.MobileCLIP` path with a local dummy `mobileclip_s0.pt` checkpoint to avoid downloading Apple weights

## Tests
- `git diff --check`
- Python compile check for all Python files
- `ultralytics.nn.text_model.MobileCLIP` compatibility smoke test

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📘 This PR updates the README to clarify that this Ultralytics fork stays lightweight and focused on the core MobileCLIP Python API, while newer upstream-only assets like MobileCLIP2 and MobileCLIP-S3/S4 should be obtained from Apple’s official repository.

### 📊 Key Changes
- Added a new **“What’s New”** note explaining that Apple’s upstream repo now includes:
  - MobileCLIP2
  - MobileCLIP-S3/S4 resources
- Clarified that this fork **does not vendor** those newer upstream assets locally.
- Updated the README to direct users to the upstream [Apple ML-MobileCLIP repository](https://github.com/apple/ml-mobileclip) for:
  - MobileCLIP2 assets
  - MobileCLIP-S3/S4 OpenCLIP resources
  - training updates
  - result artifacts
- Added explanation that this repository intentionally remains a **small, `pyproject.toml`-based package** compatible with Ultralytics installs ⚙️

### 🎯 Purpose & Impact
- Helps users quickly understand **which resources are available here vs. upstream** ✅
- Prevents confusion for anyone expecting MobileCLIP2 or S3/S4 files to be included in this fork 📦
- Keeps this repo **leaner and easier to maintain**, which supports smoother installation and integration with Ultralytics tools 🚀
- Improves documentation clarity for both developers and general users by clearly separating the role of this fork from Apple’s upstream project 🧭