### PR TITLE
Bump actions/checkout from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6


### PR DESCRIPTION
Bump actions/checkout from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions checkout step from `actions/checkout@v6` to `actions/checkout@v7` in the CI workflow.

### 📊 Key Changes
- Upgraded the **GitHub Actions checkout action** in `.github/workflows/ci.yml`
  - From: `actions/checkout@v6`
  - To: `actions/checkout@v7`
- No application code or model behavior was changed.
- The update only affects the repository’s **continuous integration (CI) pipeline** ⚙️

### 🎯 Purpose & Impact
- Keeps the CI workflow aligned with the **latest GitHub Actions version** 🚀
- Helps improve **workflow maintenance, compatibility, and long-term support**
- Reduces the chance of issues caused by relying on an older action version
- No direct impact for end users, but it can make development and testing more reliable for contributors ✅