### PR TITLE
Revert "Update torch requirement from >=2.1.0 to >=2.12.1"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
 full = [
     "clip-benchmark>=1.4.0",  # Benchmarking tools for CLIP models
     "datasets",               # Hugging Face datasets library
-    "torch>=2.12.1",           # PyTorch deep learning framework
+    "torch>=2.1.0",           # PyTorch deep learning framework
     "torchvision>=0.16.0"     # Computer vision library for PyTorch
 ]
 


### PR DESCRIPTION
Reverts ultralytics/mobileclip#33

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated the optional `full` dependency set to require a valid PyTorch version, improving installation reliability ⚙️

### 📊 Key Changes
- Changed the PyTorch requirement from `torch>=2.12.1` to `torch>=2.1.0` in `pyproject.toml` 📦
- Keeps `torchvision>=0.16.0` unchanged for compatibility with the updated PyTorch baseline 🖼️
- Applies only to the optional `full` install dependencies, not the core package requirements ✅

### 🎯 Purpose & Impact
- Fixes an invalid or unavailable PyTorch version requirement, preventing install errors 🚀
- Improves compatibility for users installing the full MobileCLIP environment 🔧
- Makes setup smoother for benchmarking, dataset workflows, and PyTorch-based computer vision tasks 🙌