### PR TITLE
Bump actions/setup-python from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v7
       
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
       


### PR DESCRIPTION
Bump actions/setup-python from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates the GitHub Actions Python setup action to its latest major version for CI workflows. ⚙️

### 📊 Key Changes
- Replaced `actions/setup-python@v6` with `actions/setup-python@v7` in `.github/workflows/ci.yml`.
- No application or model code was changed.

### 🎯 Purpose & Impact
- Keeps the CI pipeline aligned with the latest supported GitHub Actions tooling. ✅
- May improve Python environment setup reliability and access to current action features.
- Changes are limited to development and testing workflows, with no direct impact on end-user functionality.