### PR TITLE
Ruff 0.16.0 compatibility changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,16 +20,16 @@ jobs:
       matrix:
         python-version: [3.11, 3.13]
         pytorch-version: [2.5.0, 2.8.0]
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
-      
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
-      
+
       - name: Install dependencies
         run: |
           pip install uv

--- a/ios_app/MobileCLIPExplore/Models.swift
+++ b/ios_app/MobileCLIPExplore/Models.swift
@@ -29,7 +29,7 @@ public struct ModelConfiguration: Identifiable, Hashable {
         lhs.name == rhs.name
     }
 
-    public func hash(into hasher: inout Hasher) {
+    public func hash(into hasher: inout Hasher) {  // codespell:ignore inout
         hasher.combine(name)
     }
 }

--- a/ios_app/MobileCLIPExplore/Tokenizer/CLIPTokenizer.swift
+++ b/ios_app/MobileCLIPExplore/Tokenizer/CLIPTokenizer.swift
@@ -28,7 +28,7 @@ struct BytePair: Hashable {
     static func == (lhs: BytePair, rhs: BytePair) -> Bool {
         return lhs.a == rhs.a && lhs.b == rhs.b
     }
-    func hash(into hasher: inout Hasher) {
+    func hash(into hasher: inout Hasher) {  // codespell:ignore inout
         hasher.combine(a)
         hasher.combine(b)
     }

--- a/mobileclip/modules/common/mobileone.py
+++ b/mobileclip/modules/common/mobileone.py
@@ -243,7 +243,7 @@ class MobileOneBlock(nn.Module):
         return kernel_final, bias_final
 
     def _fuse_bn_tensor(self, branch: nn.Sequential | nn.BatchNorm2d) -> tuple[torch.Tensor, torch.Tensor]:
-        """Method to fuse batchnorm layer with preceeding conv layer. Reference:
+        """Method to fuse batchnorm layer with preceding conv layer. Reference:
         https://github.com/DingXiaoH/RepVGG/blob/main/repvgg.py#L95.
 
         Args:


### PR DESCRIPTION
Applies the workflow formatting and clears the spelling diagnostics exposed by the Ultralytics Actions log. The Swift inout keyword remains unchanged and is narrowly annotated for codespell.

Deleted: trailing whitespace in the CI workflow and the misspelled preceeding text.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🧹 Makes small documentation, spelling, and formatting improvements without changing MobileCLIP functionality.

### 📊 Key Changes

- 📝 Corrects the typo “preceeding” to “preceding” in the MobileOne batch-normalization fusion documentation.
- 🔤 Adds `codespell:ignore` comments for valid Swift syntax involving `inout`.
- 🧼 Cleans up whitespace in the GitHub Actions CI workflow.
- ⚙️ Leaves model architecture, inference behavior, and CI logic unchanged.

### 🎯 Purpose & Impact

- ✅ Prevents false-positive spelling warnings from Swift’s `inout` keyword.
- 📚 Improves code clarity and documentation quality.
- 🔄 Maintains existing CI coverage across Python 3.11/3.13 and PyTorch 2.5.0/2.8.0.
- 🚀 No expected user-facing behavior or performance impact.